### PR TITLE
fix: Search vars files from roles vars folder only

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -4,10 +4,12 @@
   with_first_found:
     - files:
         - >-
-          vars/{{ ansible_os_family }}-{{
+          {{ ansible_os_family }}-{{
           ansible_distribution_major_version }}.yml
         - >-
-          vars/{{ ansible_os_family }}.yml
+          {{ ansible_os_family }}.yml
+      paths:
+        - "{{ role_path }}/vars"
       skip: true
 
 - name: python_packages


### PR DESCRIPTION
Hello.

I have a problem with your role usage with `include_role` task when my parent role has the same vars files as your. 
I have var file matched to name:
"{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml" 
And your role indlude file from parent role and skip var what needed.
I propose to close the search path in vars folder of the role.